### PR TITLE
Switch SDK package to @applitools/eyes-selenium

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "author": "Raja Rao DV",
   "license": "ISC",
   "devDependencies": {
-    "mocha": "^6.2.3",
+    "@applitools/eyes-selenium": "latest",
     "chromedriver": "latest",
-    "eyes.selenium": "latest",
-    "selenium-webdriver": "^3.6.0"
+    "mocha": "^6.2.3",
+    "selenium-webdriver": "^4.0.0-alpha.7"
   }
 }

--- a/test/example.test.js
+++ b/test/example.test.js
@@ -2,7 +2,7 @@
 
 require('chromedriver');
 const { Builder, Capabilities, By} = require('selenium-webdriver');
-const { Eyes, Target, GeneralUtils} = require('eyes.selenium');
+const { Eyes, Target, BatchInfo} = require('@applitools/eyes-selenium');
 
 describe('DemoApp - Original', function () {
     let eyes, driver;
@@ -16,11 +16,7 @@ describe('DemoApp - Original', function () {
         eyes.setApiKey('APPLITOOLS_API_KEY');
 
         // set new batch
-        eyes.setBatch({
-            id: GeneralUtils.guid(),
-            name: 'Demo batch',
-            startedAt: new Date().toUTCString(),
-        });
+        eyes.setBatch(new BatchInfo('Demo batch'))
 
         // Use Chrome browsert
         driver = await new Builder()


### PR DESCRIPTION
The package `@applitools/eyes-selenium` now support both Selenium 3 and Selenium 4.
Let's rename this tutorial `tutorial-selenium3-javascript` (or whatever variation you choose) and also the Selenium 4 tutorials names to include `4`.